### PR TITLE
Update target for MedicationRequest.requester 

### DIFF
--- a/StructureDefinition/NHSDigital-MedicationRequest.StructureDefinition.xml
+++ b/StructureDefinition/NHSDigital-MedicationRequest.StructureDefinition.xml
@@ -388,7 +388,7 @@
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.nhs.uk/StructureDefinition/NHSDigital-PractitionerRole-EPSLegal" />
-        <targetProfile value="https://fhir.nhs.uk/StructureDefinition/NHSDigital-PractitionerRole" />
+        <targetProfile value="https://fhir.nhs.uk/StructureDefinition/NHSDigital-PractitionerRole-SDS" />
       </type>
       <constraint>
         <key value="eps-3" />

--- a/StructureDefinition/NHSDigital-MedicationRequest.StructureDefinition.xml
+++ b/StructureDefinition/NHSDigital-MedicationRequest.StructureDefinition.xml
@@ -388,6 +388,7 @@
       <type>
         <code value="Reference" />
         <targetProfile value="https://fhir.nhs.uk/StructureDefinition/NHSDigital-PractitionerRole-EPSLegal" />
+        <targetProfile value="https://fhir.nhs.uk/StructureDefinition/NHSDigital-PractitionerRole" />
       </type>
       <constraint>
         <key value="eps-3" />


### PR DESCRIPTION
To also include NHSDigital-PractitionerRole-SDS

This will specify cancellation requests should include the SDS User ID in PractitionerRole. Specific guidance for conformance to either profile will be given in the Medicines IG.