### PR TITLE
AEA-2742: Removal of mandatory dispenseRequest on responses

### DIFF
--- a/StructureDefinition/NHSDigital-MedicationRequest-Outcome.StructureDefinition.xml
+++ b/StructureDefinition/NHSDigital-MedicationRequest-Outcome.StructureDefinition.xml
@@ -127,10 +127,6 @@
       <path value="MedicationRequest.groupIdentifier.value" />
       <min value="1" />
     </element>
-    <element id="MedicationRequest.dispenseRequest">
-      <path value="MedicationRequest.dispenseRequest" />
-      <min value="1" />
-    </element>
     <element id="MedicationRequest.dispenseRequest.performer">
       <path value="MedicationRequest.dispenseRequest.performer" />
       <definition value="Indicates the intended dispensing Pharmacy specified by the patient. Can be sourced from nominatedPharmacy in the Patient Demographics Service (PDS)" />


### PR DESCRIPTION
Removing the change to MedicationRequest-Outcome to make dispenseRequest Mandatory.
This is so that responses to cancellation messages pass FHIR validation (dispenseRequest cannot be mapped on to a V3 CancellationRequest so cannot be returned in the response).
This is only to support the FHIR Facade and shouldn't be an issue for NextGen