### PR TITLE
Removal of fixed value at slice level

### DIFF
--- a/StructureDefinition/NHSDigital-ServiceRequest.StructureDefinition.xml
+++ b/StructureDefinition/NHSDigital-ServiceRequest.StructureDefinition.xml
@@ -182,9 +182,6 @@
       <path value="ServiceRequest.code.coding" />
       <sliceName value="SNOMEDProcedureCode" />
       <min value="1" />
-      <fixedCoding>
-        <system value="http://snomed.info/sct" />
-      </fixedCoding>
     </element>
     <element id="ServiceRequest.code.coding:SNOMEDProcedureCode.system">
       <path value="ServiceRequest.code.coding.system" />


### PR DESCRIPTION
Fixed value still exists at the coding.system level for this slice. Current StructureDefinition does not allow adding a code to the coding element