### PR TITLE
Proposal to remove mandating of meta.lastUpdated field in OperationOutcome

### DIFF
--- a/StructureDefinition/NHSDigital-OperationOutcome.StructureDefinition.xml
+++ b/StructureDefinition/NHSDigital-OperationOutcome.StructureDefinition.xml
@@ -22,12 +22,7 @@
     <element id="OperationOutcome.meta">
       <path value="OperationOutcome.meta" />
       <definition value="The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.&#xD;&#xA;&#xD;&#xA;```json&#xD;&#xA; &quot;meta&quot; : {&#xD;&#xA;        &quot;lastUpdated&quot; : &quot;2021-04-21T16:58:00+00:00&quot;&#xD;&#xA;    }&#xD;&#xA;```" />
-      <min value="1" />
       <mustSupport value="true" />
-    </element>
-    <element id="OperationOutcome.meta.lastUpdated">
-      <path value="OperationOutcome.meta.lastUpdated" />
-      <min value="1" />
     </element>
     <element id="OperationOutcome.extension">
       <path value="OperationOutcome.extension" />


### PR DESCRIPTION
To reduce burden on EPS when generating response messages, may impact other programmes which want to mandate filling of the field, OperationOutcome.meta.lastUpdated