### PR TITLE
Update/qc checker

### DIFF
--- a/.github/workflows/QualityControlChecker.yml
+++ b/.github/workflows/QualityControlChecker.yml
@@ -14,4 +14,4 @@ on:
 jobs:
   # This workflow contains a single job called "call-workflow" which references the FHIR validator repo
   call-workflow:
-    uses: NHSDigital/IOPS-FHIR-Test-Scripts/.github/workflows/QualityControlCheckerNHSE.yml@main
+    uses: NHSDigital/IOPS-FHIR-Test-Scripts/.github/workflows/QualityControlChecker.yml@main

--- a/CapabilityStatement/CapabilityStatement-England.xml
+++ b/CapabilityStatement/CapabilityStatement-England.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CapabilityStatement xmlns="http://hl7.org/fhir">
-    <id value="England-CapabilityStatement" />
-    <url value="https://fhir.nhs.uk/CapabilityStatement/England-CapabilityStatement" />
+    <id value="CapabilityStatement-England" />
+    <url value="https://fhir.nhs.uk/CapabilityStatement/CapabilityStatement-England" />
     <version value="1.0.0" />
-    <name value="EnglandCapabilityStatement" />
-    <title value="England CapabilityStatement" />
+    <name value="CapabilityStatementEngland" />
+    <title value="CapabilityStatementEngland" />
     <status value="draft" />
     <date value="2023-08-18" />
     <publisher value="NHS England" />


### PR DESCRIPTION
Updated QCChecker action to run on the same file as UKCore. This makes updating a lot easier and less error prone. Note that the action has now been set up to fail if it finds anything incorrect to increase awareness. Code can still be merged by bypassing as admin.

Updated CapabilityStatement naming convention to align with Extension, ValueSet and CodeSystem assets & UKCore.