### PR TITLE
Change line breaks to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-# Declare files that will always have CRLF line endings on checkout.
-*.xml text eol=crlf
-*.json text eol=crlf
+# normalizes line endings to LF for all text files checked into your repo while leaving local line endings untouched in the working tree:
+* text=auto

--- a/.github/workflows/FindReplaceTabSpace.yml
+++ b/.github/workflows/FindReplaceTabSpace.yml
@@ -1,0 +1,10 @@
+name: Replace tab with 2 spaces - test
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Find and Replace
+        run: find ./ -type f -name *.xml -exec sed -i -e '  /  /g' {} \;
+


### PR DESCRIPTION
This PR has changed the whitespace from CRLF to LF only. This was done by adding the .gitattribute file then using the following code 
`git add --renormalize .` 

This has been decided through the DA call.