### PR TITLE
message-events

### DIFF
--- a/codesystems/message-event.xml
+++ b/codesystems/message-event.xml
@@ -1,0 +1,111 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+  <id value="message-events" />
+  <url value="https://fhir.nhs.uk/CodeSystem/message-event" />
+  <identifier>
+    <system value="https://fhir.nhs.uk/identifier/CodeSystem" />
+    <value value="message-events" />
+  </identifier>
+  <version value="1.0.19" />
+  <name value="NHSDigitalMessageEvent" />
+  <title value="Message Events" />
+  <status value="draft" />
+  <date value="2022-03-25" />
+  <publisher value="NHS Digital" />
+  <contact>
+    <name value="NHS Digital" />
+    <telecom>
+      <system value="email" />
+      <value value="interoperabilityteam@nhs.net" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Common messaging events." />
+  <copyright value="Copyright © 2019 NHS Digital" />
+  <caseSensitive value="true" />
+  <content value="complete" />
+  <concept>
+    <code value="prescription-order" />
+    <display value="Prescription Order" />
+    <definition value="Pharmacy/treatment encoded order" />
+  </concept>
+  <concept>
+    <code value="prescription-order-update" />
+    <display value="Prescription Order Update" />
+  </concept>
+  <concept>
+    <code value="prescription-order-response" />
+    <display value="Prescription Order Response" />
+    <definition value="Pharmacy/treatment order acknowledgement" />
+    <property>
+      <code value="deprecated" />
+      <valueBoolean value="true" />
+    </property>
+  </concept>
+  <concept>
+    <code value="dispense-notification" />
+    <display value="Dispense Notification" />
+    <definition value="Dispense Notification" />
+  </concept>
+  <concept>
+    <code value="unsolicited-observations" />
+    <display value="Unsolicited Observations" />
+  </concept>
+  <concept>
+    <code value="patient-notification" />
+    <display value="Patient Notifications" />
+    <definition value="Used to send CommunicationRequests" />
+  </concept>
+  <concept>
+    <code value="vaccinations" />
+    <display value="Vaccinations" />
+  </concept>
+  <concept>
+    <code value="document" />
+    <display value="Document" />
+    <definition value="Original document notification and content" />
+  </concept>
+  <concept>
+    <code value="document-notification" />
+    <display value="Document Notification" />
+    <definition value="Original document notification" />
+  </concept>
+  <concept>
+    <code value="dispense-notification-update" />
+    <display value="Dispense Notification Update" />
+    <definition value="This message is used by the Dispensing System to notify the EPS System of an amendment to a previousy submitted dispense-notification" />
+    <property>
+      <code value="deprecated" />
+      <valueBoolean value="true" />
+    </property>
+  </concept>
+  <concept>
+    <code value="appointment" />
+    <display value="Appointment" />
+    <definition value="Pre-admit a patient / Patient Appointment" />
+  </concept>
+  <concept>
+    <code value="referral" />
+    <display value="Patient Referral" />
+    <definition value="Patient referral/handover" />
+  </concept>
+  <concept>
+    <code value="notification" />
+    <display value="Event Notification" />
+    <definition value="Event Notification" />
+  </concept>
+  <concept>
+    <code value="encounter" />
+    <display value="Patient Encounter" />
+    <definition value="Can be used for an admission/discharge report or consulations" />
+  </concept>
+  <concept>
+    <code value="patient" />
+    <display value="Patient Demographics" />
+    <definition value="Patient demographic change events" />
+  </concept>
+  <concept>
+    <code value="unsolicited-action" />
+    <display value="Unsolicited actions" />
+    <definition value="Unsolicited actions using FHIR Task" />
+  </concept>
+</CodeSystem>

--- a/valuesets/nhsdigital-message-events.xml
+++ b/valuesets/nhsdigital-message-events.xml
@@ -1,90 +1,90 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-	<id value="nhsdigital-message-events"/>
-	<url value="https://fhir.nhs.uk/ValueSet/NHSDigital-message-events"/>
-	<version value="1.0.12"/>
-	<name value="NHSMessageEvents"/>
-	<status value="draft"/>
-	<description value="A ValueSet to identify the type of FHIR Message"/>
-	<compose>
-		<include>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-		</include>
-	</compose>
-	<expansion>
-		<identifier value="urn:uuid:8692f1c5-6863-4f4f-b02d-68595a8eddf7"/>
-		<timestamp value="2024-05-24T11:15:23+00:00"/>
-		<total value="12"/>
-		<parameter>
-			<name value="version"/>
-			<valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15"/>
-		</parameter>
-		<parameter>
-			<name value="used-codesystem"/>
-			<valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15"/>
-		</parameter>
-		<parameter>
-			<name value="warning-draft"/>
-			<valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15"/>
-		</parameter>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="appointment"/>
-			<display value="Appointment"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="dispense-notification"/>
-			<display value="Dispense Notification"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="dispense-notification-update"/>
-			<display value="Dispense Notification Update"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="document"/>
-			<display value="Document"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="document-notification"/>
-			<display value="Document Notification"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="patient-notification"/>
-			<display value="Patient Notifications"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="referral"/>
-			<display value="Patient Referral"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="prescription-order"/>
-			<display value="Prescription Order"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="prescription-order-response"/>
-			<display value="Prescription Order Response"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="prescription-order-update"/>
-			<display value="Prescription Order Update"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="unsolicited-observations"/>
-			<display value="Unsolicited Observations"/>
-		</contains>
-		<contains>
-			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
-			<code value="vaccinations"/>
-			<display value="Vaccinations"/>
-		</contains>
-	</expansion>
+  <id value="nhsdigital-message-events" />
+  <url value="https://fhir.nhs.uk/ValueSet/NHSDigital-message-events" />
+  <version value="1.0.12" />
+  <name value="NHSMessageEvents" />
+  <status value="draft" />
+  <description value="A ValueSet to identify the type of FHIR Message" />
+  <compose>
+    <include>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+    </include>
+  </compose>
+  <expansion>
+    <identifier value="urn:uuid:8692f1c5-6863-4f4f-b02d-68595a8eddf7" />
+    <timestamp value="2024-05-24T11:15:23+00:00" />
+    <total value="12" />
+    <parameter>
+      <name value="version" />
+      <valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15" />
+    </parameter>
+    <parameter>
+      <name value="used-codesystem" />
+      <valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15" />
+    </parameter>
+    <parameter>
+      <name value="warning-draft" />
+      <valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15" />
+    </parameter>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="appointment" />
+      <display value="Appointment" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="dispense-notification" />
+      <display value="Dispense Notification" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="dispense-notification-update" />
+      <display value="Dispense Notification Update" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="document" />
+      <display value="Document" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="document-notification" />
+      <display value="Document Notification" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="patient-notification" />
+      <display value="Patient Notifications" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="referral" />
+      <display value="Patient Referral" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="prescription-order" />
+      <display value="Prescription Order" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="prescription-order-response" />
+      <display value="Prescription Order Response" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="prescription-order-update" />
+      <display value="Prescription Order Update" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="unsolicited-observations" />
+      <display value="Unsolicited Observations" />
+    </contains>
+    <contains>
+      <system value="https://fhir.nhs.uk/CodeSystem/message-event" />
+      <code value="vaccinations" />
+      <display value="Vaccinations" />
+    </contains>
+  </expansion>
 </ValueSet>

--- a/valuesets/nhsdigital-message-events.xml
+++ b/valuesets/nhsdigital-message-events.xml
@@ -1,0 +1,90 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+	<id value="nhsdigital-message-events"/>
+	<url value="https://fhir.nhs.uk/ValueSet/NHSDigital-message-events"/>
+	<version value="1.0.12"/>
+	<name value="NHSMessageEvents"/>
+	<status value="draft"/>
+	<description value="A ValueSet to identify the type of FHIR Message"/>
+	<compose>
+		<include>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+		</include>
+	</compose>
+	<expansion>
+		<identifier value="urn:uuid:8692f1c5-6863-4f4f-b02d-68595a8eddf7"/>
+		<timestamp value="2024-05-24T11:15:23+00:00"/>
+		<total value="12"/>
+		<parameter>
+			<name value="version"/>
+			<valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15"/>
+		</parameter>
+		<parameter>
+			<name value="used-codesystem"/>
+			<valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15"/>
+		</parameter>
+		<parameter>
+			<name value="warning-draft"/>
+			<valueUri value="https://fhir.nhs.uk/CodeSystem/message-event|1.0.15"/>
+		</parameter>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="appointment"/>
+			<display value="Appointment"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="dispense-notification"/>
+			<display value="Dispense Notification"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="dispense-notification-update"/>
+			<display value="Dispense Notification Update"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="document"/>
+			<display value="Document"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="document-notification"/>
+			<display value="Document Notification"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="patient-notification"/>
+			<display value="Patient Notifications"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="referral"/>
+			<display value="Patient Referral"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="prescription-order"/>
+			<display value="Prescription Order"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="prescription-order-response"/>
+			<display value="Prescription Order Response"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="prescription-order-update"/>
+			<display value="Prescription Order Update"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="unsolicited-observations"/>
+			<display value="Unsolicited Observations"/>
+		</contains>
+		<contains>
+			<system value="https://fhir.nhs.uk/CodeSystem/message-event"/>
+			<code value="vaccinations"/>
+			<display value="Vaccinations"/>
+		</contains>
+	</expansion>
+</ValueSet>


### PR DESCRIPTION
added the valueset and codesystem for message events. 

Changes from the original:
- valueset has had BaRS codesystem removed
- valueset set to draft
- valueset has been expanded

It is possible that we rename the file, along with name, id, title, and keep the original url without causing any breaking changes, but whther we do this now or through the C&TA sprint, I'm thinking the latter as programmes can have their input into the changes.