### PR TITLE
Updated CodeSystems to add new codes for EPS

### DIFF
--- a/CodeSystem/CodeSystem-medicationdispense-endorsement.json
+++ b/CodeSystem/CodeSystem-medicationdispense-endorsement.json
@@ -8,12 +8,12 @@
             "value": "medicationdispense-endorsement"
         }
     ],
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "DispensingEndorsement",
     "title": "Dispensing Endorsement",
     "status": "draft",
     "experimental": true,
-    "date": "2013-04-21",
+    "date": "2024-08-08",
     "publisher": "NHS Digital",
     "contact":  [
         {
@@ -95,6 +95,10 @@
         {
             "code": "PD",
             "display": "Packaged Doses"
+        },
+        {
+            "code": "WR",
+            "display": "Waste Reduction (Wales Only)"
         }
     ]
 }

--- a/CodeSystem/CodeSystem-prescription-charge-exemption.xml
+++ b/CodeSystem/CodeSystem-prescription-charge-exemption.xml
@@ -145,10 +145,10 @@
     </concept>
     <concept>
         <code value="1001"></code>
-        <display value="Welsh Prescription Welsh Dispenser – No Charge (Wales Only)"></code>
+        <display value="Welsh Prescription Welsh Dispenser – No Charge (Wales Only)" />
     </concept>
     <concept>
         <code value="1002"></code>
-        <display value="Welsh Entitlement Card (Wales Only)"></code>
+        <display value="Welsh Entitlement Card (Wales Only)" />
     </concept>
 </CodeSystem>

--- a/CodeSystem/CodeSystem-prescription-charge-exemption.xml
+++ b/CodeSystem/CodeSystem-prescription-charge-exemption.xml
@@ -5,12 +5,12 @@
         <system value="https://fhir.nhs.uk/identifier/CodeSystem" />
         <value value="prescription-charge-exemption" />
     </identifier>
-    <version value="1.0.3" />
+    <version value="1.0.4" />
     <name value="PrescriptionChargeExemption" />
     <title value="Prescription Charge Exemption" />
     <status value="draft" />
     <experimental value="true" />
-    <date value="2023-02-03" />
+    <date value="2024-08-08" />
     <publisher value="NHS Digital" />
     <contact>
         <name value="Interoperability Team" />
@@ -107,40 +107,48 @@
         <code value="0019"></code>
         <display value="Was prescribed free-of-charge TB medication" />
     </concept>
-	<concept>
+    <concept>
         <code value="0020"></code>
         <display value="HRT only Prescription prepayment certificate" />
     </concept>
-	<concept>
+    <concept>
         <code value="9180"></code>
         <display value="Real-time exemption checking" />
     </concept>
-	<concept>
+    <concept>
         <code value="9181"></code>
         <display value="Maternity exemption certificate" />
     </concept>
-	<concept>
+    <concept>
         <code value="9182"></code>
         <display value="Medical exemption certificate" />
     </concept>
-	<concept>
+    <concept>
         <code value="9183"></code>
         <display value="Tax credit exemption certificate" />
     </concept>
-	<concept>
+    <concept>
         <code value="9184"></code>
         <display value="Is named on a current HC2 charges certificate" />
     </concept>
-	<concept>
+    <concept>
         <code value="9185"></code>
         <display value="Prescription prepayment certificate" />
     </concept>
-	<concept>
+    <concept>
         <code value="9186"></code>
         <display value="HRT Only PPC" />
     </concept>
-	<concept>
+    <concept>
         <code value="9200"></code>
         <display value="All DWP" />
+    </concept>
+    <concept>
+        <code value="1001"></code>
+        <display value="Welsh Prescription Welsh Dispenser – No Charge (Wales Only)"></code>
+    </concept>
+    <concept>
+        <code value="1002"></code>
+        <display value="Welsh Entitlement Card (Wales Only)"></code>
     </concept>
 </CodeSystem>


### PR DESCRIPTION
**WARNING: THIS PR IS FOR NHS DIGITAL IG. DO NOT MERGE UNTIL REVIEWS ARE COMPLETE.**

Updated CodeSystem-medicationdispense-endorsement.json
- added code 'WR' / display 'Waste Reduction (Wales Only)'

Updated CodeSystem-prescription-charge-exemption.xml
- added code '1001' / display 'Welsh Prescription Welsh Dispenser – No Charge (Wales Only)'
- added code '1002' / display 'Welsh Entitlement Card (Wales Only)'
- minor tweak to format/tabs

Upped version and updated date for both assets.